### PR TITLE
Add start and stop methods to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ Future<void> main() async {
 
   runApp(MyApp());
 }
+
+startLocationTracking() async {
+  await BackgroundLocationTrackerManager.startTracking();
+}
+
+stopLocationTracking() async {
+  await BackgroundLocationTrackerManager.stopTracking();
+}
+
 ```
 
 # FAQ:


### PR DESCRIPTION
Spend an entire day trying to figure out why the tracking never started for me. Then ran the example app to understand that 
the button calls the `startTracking` method. 

Felt that having the method in the README would really help everyone.
